### PR TITLE
48 add user invite associativity persistence across startups

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1144,7 +1144,7 @@ async def set_user(
             try:
                 await member.add_roles(ra_role, reason="Manual override")
             except discord.errors.Forbidden:
-                await ctx.respond(
+                await ctx.followup.send(
                     content="I don't have permission to modify this user's roles. Ensure that my bot role is higher on the role list than the user's highest role.",
                     ephemeral=True,
                 )
@@ -1155,7 +1155,7 @@ async def set_user(
                 await member.add_roles(residents_role, reason="Manual override")
             else:
                 await ctx.followup.send(
-                    content="There is no role named 'residents' in this guild, but the user was set to be an RA. User will not receive any elevated RA role.",
+                    content="There is no role named 'residents' in this guild, but the user was set not to be an RA. User will not receive any 'residents' role.",
                     ephemeral=True,
                 )
         except discord.errors.Forbidden:

--- a/bot.py
+++ b/bot.py
@@ -1415,9 +1415,6 @@ async def prune_pending(ctx):
             # Get DM channel
             dm_channel = await member.create_dm()
 
-            num_pruned += 1
-            pruned.append(member)
-
             # Notify them
             if dm_channel:
                 try:
@@ -1447,6 +1444,9 @@ async def prune_pending(ctx):
                     f"Member {member.name}[{member.id}] cannot be kicked due to a permissions error."
                 )
                 continue
+            
+            num_pruned += 1
+            pruned.append(member)
 
     # Respond with ephemeral list of members pruned
     message_content = f"**{num_pruned} members were pruned:**\n"

--- a/bot.py
+++ b/bot.py
@@ -2,7 +2,6 @@
 
 import os
 from sqlite3 import IntegrityError
-from tkinter import E
 from urllib.request import urlopen
 import discord
 import discord.ext

--- a/util/db.py
+++ b/util/db.py
@@ -122,3 +122,23 @@ class DbCategory(Base):
     role_id: {self.role_id}
 }}
 """
+
+class DbVerifyingUser(Base):
+    """Represents a user that is in the verification process, or data used for verification, in the bot's SQLite3 database.
+    ## Attributes
+    
+    
+    """
+    __tablename__ = "verifyingusers"
+    
+    # User ID
+    ID = Column("id", BigInteger().with_variant(Integer, "sqlite"), primary_key=True)
+    # Invite code user used to join
+    invite_code = Column("invite", String)
+
+    def __repr__(self):
+        return f"""VerifyingUser: {{
+    user_id: {self.ID}
+    invite_code: {self.invite_code}
+}}
+"""


### PR DESCRIPTION
Resolves #48 by adding a new database table that tracks invite codes for users as soon as they join or select in a dropdown if an invite is **unambiguously resolvable.** In `verify`, when checking for an invite code to use for a user, if the bot has been interrupted and its `user_to_invite` cache is no longer valid, the bot will attempt to read from this database to see if it has previously **unambiguously** resolved an invite for this user, and will use that invite instead. This should allow hot patches to be easier to deploy by allowing users who have not yet initiated verification to remain unaffected when the bot restarts for the patch. If this does not work, this PR also builds off of the `prune_pending` command added to `dev` in 83ec2877084157cc837184462da5961be5820a2e that allows all users without any roles (besides @/everyone) to be kicked and notified that they should re-join with the invite code their RA sent them.

In either case, it should now be significantly simpler to handle situations in which users have failed to verify in a reasonable time and the verification process was interrupted by a hotfix.  